### PR TITLE
Fix "Raw command arguments must be scalar values!"

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -329,7 +329,7 @@ class Connection extends \yii\redis\Connection
         }
         \Yii::debug("Executing Redis Command: {$name}", __METHOD__);
         try {
-            $result = call_user_func_array([$this->_redis, 'rawCommand'], array_merge(explode(' ', $name), $raw));
+            $result = call_user_func_array([$this->_redis, 'rawCommand'], array_map('strval', array_merge(explode(' ', $name), $raw)));
             return $this->parseResponse($result);
         } catch (\RedisException $e) {
             throw new Exception($e->getMessage(), $e->getTrace(), $e->getCode(), $e->getPrevious());


### PR DESCRIPTION
In some cases, arguments for rawCommand will be of different type, like boolean - Phpredis will not accept values other than string, int or float. This happens especially when using Yii2 Redis Queue